### PR TITLE
Add command parameters for including a description

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ with github remote repo under the same name.
 * ```-L -l``` specifies initiating a local repo
 * ```-P -p``` specifies the creation of a private repo --Note: a private repo
 is only possible with a remote initiation.
+* ```-D <description> -d <description>``` specifies the description to add to
+the repo and README
+* ```-DO <description> -do <description>``` specifies the description to add 
+to the repo only

--- a/create.py
+++ b/create.py
@@ -2,13 +2,18 @@ import os
 import sys
 from github import Github
 
+# Command parameters
 remote = True
 private = False
+description = "."
+description_only = False
 
+# Passed arguments
 github_token = str(sys.argv[1])
 project_name = str(sys.argv[2])
 list_all_args = sys.argv[3:]
 
+# Parse commands
 while len(list_all_args) > 0:
     command = list_all_args.pop(0)
     if command.lower() == "-r":
@@ -17,15 +22,21 @@ while len(list_all_args) > 0:
         remote = False
     elif command.lower() == "-p":
         private = True
+    elif command.lower() == "-d" and len(list_all_args) > 0:
+        description = list_all_args.pop(0)
+    elif command.lower() == "-do" and len(list_all_args) > 0:
+        description = list_all_args.pop(0)
+        description_only = True
 
 commands = None
 location = None
 
+# Initialise remote repo
 if remote:
     github = Github(github_token)
     user = github.get_user()
     login = user.login
-    repo = user.create_repo(project_name, private=private)
+    repo = user.create_repo(project_name, private=private, description=description)
 
     commands = [f'echo # {repo.name} >> README.md',
                 f'git remote add origin https://github.com/{login}/{project_name}.git',
@@ -35,15 +46,20 @@ if remote:
 
     location = "remote"
 
+# Initialise local repo
 elif not remote:
 
-    commands = [f'echo # {project_name} >> README.md',
+    commands = [f'echo # {project_name}>> README.md',
                 'git add .',
                 'git commit -m "Initial commit"']
 
     location = "local"
 
+# Add description to readme
+if description != "." and not description_only:
+    commands.insert(1, f'echo {description}>> README.md')
 
+# Executes commands
 for c in commands:
     os.system(c)
 


### PR DESCRIPTION
-d <description> includes the description in the repo description and the readme
-do <description includes the description in the repo description only
Signed-off-by: Adam Plaskitt <adam.plaskitt1@gmail.com>